### PR TITLE
Add Portuguese accent stripping helper for routing and guardrails

### DIFF
--- a/agent-workflow/app/agents/router_agent.py
+++ b/agent-workflow/app/agents/router_agent.py
@@ -6,6 +6,7 @@ from typing import Optional
 from openai import OpenAI
 
 from app.settings import settings
+from app.utils.text import strip_portuguese_accents
 from .base import Route, RoutingDecision
 
 _DIRECT_REQUEST_PATTERNS = [
@@ -39,6 +40,7 @@ def _normalize(text: str) -> str:
     cleaned = cleaned.strip().lower()
     if not cleaned:
         return ""
+    cleaned = strip_portuguese_accents(cleaned)
     decomposed = unicodedata.normalize("NFD", cleaned)
     without_accents = "".join(ch for ch in decomposed if unicodedata.category(ch) != "Mn")
     return unicodedata.normalize("NFC", without_accents)

--- a/agent-workflow/app/guardrails/normalizer.py
+++ b/agent-workflow/app/guardrails/normalizer.py
@@ -5,6 +5,7 @@ import unicodedata
 from typing import Tuple
 
 from app.settings import settings
+from app.utils.text import strip_portuguese_accents
 
 _REMOVABLE_PATTERN = re.compile(r"[\s]{2,}")
 
@@ -39,6 +40,7 @@ def normalise_text(text: str) -> Tuple[str, bool]:
     normalised = text
 
     if settings.guardrails_normalize_remove_accents:
+        normalised = strip_portuguese_accents(normalised)
         normalised = unicodedata.normalize("NFD", normalised)
         normalised = "".join(ch for ch in normalised if unicodedata.category(ch) != "Mn")
         normalised = unicodedata.normalize("NFC", normalised)

--- a/agent-workflow/app/utils/text.py
+++ b/agent-workflow/app/utils/text.py
@@ -1,0 +1,64 @@
+"""Utility helpers for text normalisation across the agent workflow."""
+
+from __future__ import annotations
+
+from typing import Final
+
+_PORTUGUESE_ACCENT_TRANSLATION: Final[dict[int, str]] = {
+    ord("á"): "a",
+    ord("à"): "a",
+    ord("â"): "a",
+    ord("ã"): "a",
+    ord("ä"): "a",
+    ord("Á"): "A",
+    ord("À"): "A",
+    ord("Â"): "A",
+    ord("Ã"): "A",
+    ord("Ä"): "A",
+    ord("é"): "e",
+    ord("è"): "e",
+    ord("ê"): "e",
+    ord("ë"): "e",
+    ord("É"): "E",
+    ord("È"): "E",
+    ord("Ê"): "E",
+    ord("Ë"): "E",
+    ord("í"): "i",
+    ord("ì"): "i",
+    ord("î"): "i",
+    ord("ï"): "i",
+    ord("Í"): "I",
+    ord("Ì"): "I",
+    ord("Î"): "I",
+    ord("Ï"): "I",
+    ord("ó"): "o",
+    ord("ò"): "o",
+    ord("ô"): "o",
+    ord("õ"): "o",
+    ord("ö"): "o",
+    ord("Ó"): "O",
+    ord("Ò"): "O",
+    ord("Ô"): "O",
+    ord("Õ"): "O",
+    ord("Ö"): "O",
+    ord("ú"): "u",
+    ord("ù"): "u",
+    ord("û"): "u",
+    ord("ü"): "u",
+    ord("Ú"): "U",
+    ord("Ù"): "U",
+    ord("Û"): "U",
+    ord("Ü"): "U",
+    ord("ç"): "c",
+    ord("Ç"): "C",
+    ord("ñ"): "n",
+    ord("Ñ"): "N",
+}
+
+
+def strip_portuguese_accents(text: str) -> str:
+    """Replace common Portuguese accented characters with their ASCII equivalent."""
+
+    if not text:
+        return text
+    return text.translate(_PORTUGUESE_ACCENT_TRANSLATION)

--- a/agent-workflow/tests/test_guardrails.py
+++ b/agent-workflow/tests/test_guardrails.py
@@ -24,11 +24,11 @@ def test_normaliser_removes_accents_and_symbols(monkeypatch):
     monkeypatch.setattr(settings, "guardrails_normalize_remove_accents", True)
     monkeypatch.setattr(settings, "guardrails_normalize_strip_symbols", "~,^,\\u00b4,\\u00b8,`")
 
-    original = "Café façade naïve coöperative résumé: rôle in action?"
+    original = "Café façade naïve coöperative résumé: rôle em ação e coração?"
     normalised, changed = normalise_text(original)
 
     assert changed is True
-    assert normalised == "Cafe facade naive cooperative resume: role in action?"
+    assert normalised == "Cafe facade naive cooperative resume: role em acao e coracao?"
     normalised_twice, changed_twice = normalise_text(normalised)
     assert normalised_twice == normalised
     assert changed_twice is False

--- a/agent-workflow/tests/test_utils_text.py
+++ b/agent-workflow/tests/test_utils_text.py
@@ -1,0 +1,13 @@
+from app.utils.text import strip_portuguese_accents
+
+
+def test_strip_portuguese_accents_replaces_common_characters() -> None:
+    text = "Olá, coração! Informação, ação, lição, bênção, órgão, pingüim."
+    expected = "Ola, coracao! Informacao, acao, licao, bencao, orgao, pinguim."
+
+    assert strip_portuguese_accents(text) == expected
+
+
+
+def test_strip_portuguese_accents_is_noop_for_empty_input() -> None:
+    assert strip_portuguese_accents("") == ""


### PR DESCRIPTION
## Summary
- add a reusable helper that maps common Portuguese accented characters to ASCII equivalents
- normalise router and guardrail flows with the new mapping to keep keyword matching consistent
- extend guardrail coverage and add dedicated tests for the accent stripping utility

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d87523747c832e9b519dac581f3ea7